### PR TITLE
[refine] switch case use default enum.

### DIFF
--- a/src/Server/Protocol/HTTP/SimpleRoute.php
+++ b/src/Server/Protocol/HTTP/SimpleRoute.php
@@ -63,8 +63,7 @@ class SimpleRoute
         $routeInfo = self::$dispatcher->dispatch($method, $uri);
 
         switch ($routeInfo[0]) {
-            // Dispatcher::FOUND
-            case 1:
+            case Dispatcher::FOUND:
                 $handler = $routeInfo[1];
                 $vars = $routeInfo[2];
 


### PR DESCRIPTION
Use the default `FastRoute` router enums.
```php
interface Dispatcher {
    const NOT_FOUND = 0, FOUND = 1, METHOD_NOT_ALLOWED = 2;

    public function dispatch($httpMethod, $uri);
}
```